### PR TITLE
Restore YouTube playback for SABR-only streams

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -113,7 +113,8 @@
         <dependency>
             <groupId>dev.lavalink.youtube</groupId>
             <artifactId>common</artifactId>
-            <version>1.18.0</version>
+            <!-- Includes SABR playback support; not yet included in a numbered release. -->
+            <version>f45bbb7aebfcbc1c553769e04af6cd43afa8b7c3-SNAPSHOT</version>
             <scope>compile</scope>
         </dependency>
         <dependency>

--- a/src/main/java/com/jagrosh/jmusicbot/audio/PlayerManager.java
+++ b/src/main/java/com/jagrosh/jmusicbot/audio/PlayerManager.java
@@ -41,6 +41,7 @@ import com.sedmelluq.lava.extensions.youtuberotator.tools.ip.Ipv6Block;
 import dev.lavalink.youtube.YoutubeAudioSourceManager;
 import dev.lavalink.youtube.YoutubeSource;
 import dev.lavalink.youtube.clients.AndroidVr;
+import dev.lavalink.youtube.clients.ClientOptions;
 import dev.lavalink.youtube.clients.Ios;
 import dev.lavalink.youtube.clients.Music;
 import dev.lavalink.youtube.clients.Web;
@@ -71,8 +72,11 @@ public class PlayerManager extends DefaultAudioPlayerManager
             YoutubeSource.setPoTokenAndVisitorData(config.getYTPoToken(), config.getYTVisitorData());
 
         // Ios currently provides direct audio URLs when WEB returns SABR-only formats.
+        // Its search response produces NO_TRACK, which stops fallback to other clients.
+        ClientOptions iosOptions = ClientOptions.DEFAULT.copy();
+        iosOptions.setSearching(false);
         YoutubeAudioSourceManager yt = new YoutubeAudioSourceManager(true,
-                new Music(), new Ios(), new AndroidVr(), new Web(), new WebEmbedded());
+                new Music(), new Ios(iosOptions), new AndroidVr(), new Web(), new WebEmbedded());
         if (config.getYTRoutingPlanner() != YouTubeUtil.RoutingPlanner.NONE)
         {
             AbstractRoutePlanner routePlanner = YouTubeUtil.createRouterPlanner(config.getYTRoutingPlanner(), config.getYTIpBlocks());

--- a/src/main/java/com/jagrosh/jmusicbot/audio/PlayerManager.java
+++ b/src/main/java/com/jagrosh/jmusicbot/audio/PlayerManager.java
@@ -39,7 +39,12 @@ import com.sedmelluq.lava.extensions.youtuberotator.tools.ip.IpBlock;
 import com.sedmelluq.lava.extensions.youtuberotator.tools.ip.Ipv4Block;
 import com.sedmelluq.lava.extensions.youtuberotator.tools.ip.Ipv6Block;
 import dev.lavalink.youtube.YoutubeAudioSourceManager;
+import dev.lavalink.youtube.YoutubeSource;
+import dev.lavalink.youtube.clients.AndroidVr;
+import dev.lavalink.youtube.clients.Ios;
+import dev.lavalink.youtube.clients.Music;
 import dev.lavalink.youtube.clients.Web;
+import dev.lavalink.youtube.clients.WebEmbedded;
 import net.dv8tion.jda.api.entities.Guild;
 
 /**
@@ -63,9 +68,11 @@ public class PlayerManager extends DefaultAudioPlayerManager
         TransformativeAudioSourceManager.createTransforms(bot.getConfig().getTransforms()).forEach(t -> registerSourceManager(t));
 
         if (config.getYTPoToken() != null && config.getYTVisitorData() != null)
-            Web.setPoTokenAndVisitorData(config.getYTPoToken(), config.getYTVisitorData());
+            YoutubeSource.setPoTokenAndVisitorData(config.getYTPoToken(), config.getYTVisitorData());
 
-        YoutubeAudioSourceManager yt = new YoutubeAudioSourceManager(true);
+        // Ios currently provides direct audio URLs when WEB returns SABR-only formats.
+        YoutubeAudioSourceManager yt = new YoutubeAudioSourceManager(true,
+                new Music(), new Ios(), new AndroidVr(), new Web(), new WebEmbedded());
         if (config.getYTRoutingPlanner() != YouTubeUtil.RoutingPlanner.NONE)
         {
             AbstractRoutePlanner routePlanner = YouTubeUtil.createRouterPlanner(config.getYTRoutingPlanner(), config.getYTIpBlocks());


### PR DESCRIPTION
### This pull request...
  - [X] Fixes a bug
  - [ ] Introduces a new feature
  - [ ] Improves an existing feature
  - [ ] Boosts code quality or performance

### Description
Updates `youtube-source` to a SABR-capable upstream snapshot, enables the iOS client as a fallback, and applies PO token credentials consistently to supported web clients.

### Purpose
Restores playback for YouTube videos that return SABR-only streams. Previously, all default clients could fail with `No supported audio streams available`, preventing affected tracks from playing.

### Relevant Issue(s)
No linked issue.
