### PR TITLE
Add artifact uploading to build-and-test workflow

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -20,3 +20,11 @@ jobs:
           cache: maven
       - name: Build and Test with Maven
         run: mvn --batch-mode --update-snapshots verify
+      - name: Rename jar
+        run: mv target/*-All.jar JMusicBot-${{ github.sha }}.jar
+      - name: Upload jar
+        uses: actions/upload-artifact@v4
+        with:
+          name: jar
+          path: JMusicBot-${{ github.sha }}.jar
+          if-no-files-found: error


### PR DESCRIPTION
### This pull request...
  - [ ] Fixes a bug
  - [x] Introduces a new feature
  - [ ] Improves an existing feature
  - [ ] Boosts code quality or performance

### Description
This PR adds artifact uploading to the build-and-test workflow. The code for this is copied and adapted from the make-release workflow.

### Purpose
This allows people to test and/or use builds from PRs, or for which no release has been created yet.

### Relevant Issue(s)
None
